### PR TITLE
Feat/#46 우선순위 큐 구현

### DIFF
--- a/Sources/CLToaster/Common/Appearance/CLToastStyle.swift
+++ b/Sources/CLToaster/Common/Appearance/CLToastStyle.swift
@@ -31,6 +31,8 @@ public struct CLToastStyle {
   public var height: CGFloat = 100
   public var backgroundColor: UIColor = .systemGray2
   
+  public var presentPriority: CLToastPriority = .default
+  
   /**
    - Properties: ToastView
    */
@@ -51,4 +53,10 @@ public struct CLToastStyle {
   public init(title: String) {
     self.title = title
   }
+}
+
+public enum CLToastPriority: Int {
+  case urgent = 3
+  case `default` = 2
+  case `lazy` = 1
 }

--- a/Sources/CLToaster/Common/CLToastManager.swift
+++ b/Sources/CLToaster/Common/CLToastManager.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Celan on 3/26/24.
+//
+
+import Foundation

--- a/Sources/CLToaster/Common/CLToastManager.swift
+++ b/Sources/CLToaster/Common/CLToastManager.swift
@@ -1,8 +1,23 @@
 //
-//  File.swift
-//  
+//  CLToastManager.swift
+//
 //
 //  Created by Celan on 3/26/24.
 //
 
 import Foundation
+
+protocol CLToastRepository {
+  func dequeue() -> CLToastUIKitData?
+}
+
+final class CLToastManager: CLToastRepository {
+  fileprivate(set) var priorityQueue = PriorityQueue<CLToastUIKitData>(order: <)
+  func dequeue() -> CLToastUIKitData? {
+    priorityQueue.removeFirst()
+  }
+  
+  func enqueue(data: CLToastUIKitData) {
+    priorityQueue.push(data)
+  }
+}

--- a/Sources/CLToaster/Common/CLToastManager.swift
+++ b/Sources/CLToaster/Common/CLToastManager.swift
@@ -11,10 +11,10 @@ protocol CLToastRepository {
   func dequeue() -> CLToastUIKitData?
 }
 
-final class CLToastManager: CLToastRepository {
+final class CLToastRepositoryImpl: CLToastRepository {
   fileprivate(set) var priorityQueue = PriorityQueue<CLToastUIKitData>(order: <)
   func dequeue() -> CLToastUIKitData? {
-    priorityQueue.removeFirst()
+    priorityQueue.pop()
   }
   
   func enqueue(data: CLToastUIKitData) {

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -31,7 +31,7 @@ public struct PriorityQueue<T: Comparable> {
   mutating func clear() { heap.removeAll() }
   
   // MARK: - Lifecycle
-  /// Creates a new PriorityQueue with the given custom ordering function.
+  /// Creates a new Priority Queue with the given custom ordering function.
   ///
   /// - Parameters:
   ///   - order: A function that specifies whether its first argument should come after the second argument in the Priority Queue. Giving `<` means Max Heap, otherwise Min Heap.
@@ -43,11 +43,11 @@ public struct PriorityQueue<T: Comparable> {
     self.ordered = order
     self.heap = startingValues
     
-    var midIndex = heap.count / 2 - 1
+    var parentIndex = heap.count / 2 - 1
     
-    while midIndex >= 0 {
-      sink(midIndex)
-      midIndex -= 1
+    while parentIndex >= 0 {
+      sink(parentIndex)
+      parentIndex -= 1
     }
   }
   
@@ -110,14 +110,13 @@ public struct PriorityQueue<T: Comparable> {
   /// ## Example
   ///
   /// ```plain
-  /// given: heap = [1,2,3,4,5] | remove 3 | index == 2
+  /// Given: heap = [1,2,3,4,5] | remove 3 | index == 2
   /// heap[idx] goes to last position (swapAt)
   /// and pops (removeLast) then rearrange the Pritority Queue.
   /// If you removed the last item, swim doesn't get called.
   /// ```
   mutating func remove(_ item: T) {
     if let index = heap.firstIndex(of: item) {
-      
       heap.swapAt(index, heap.count - 1)
       heap.removeLast()
       
@@ -164,33 +163,44 @@ public struct PriorityQueue<T: Comparable> {
       }
     }
   }
+  
+  mutating func removeMax() -> T? {
+    let max = heap[0]
+    heap.swapAt(0, heap.count - 1)
+    sink(0)
+    return max
+  }
 }
 
 // MARK: - swim and sink
-extension PriorityQueue {
-  private mutating func sink(_ index: Int) {
-    var index = index
-    while 2 * index + 1 < heap.count {
-      var j = 2 * index + 1
-      print(#function, "SINK START", "J", j, "IDX", index)
-      
-      if j < (heap.count - 1) && ordered(heap[j], heap[j + 1]) { j += 1 }
-      if !ordered(heap[index], heap[j]) { break }
-      print(#function, "SINK END", "J", j, "IDX", index)
-      heap.swapAt(index, j)
-      index = j
-    }
-  }
-  
-  
-  private mutating func swim(_ index: Int) {
-    var index = index
-    
-    while index > 0 && ordered(heap[(index - 1) / 2], heap[index]) {
-      print(#function, "SWIM START", "IDX", index)
-      heap.swapAt((index - 1) / 2, index)
-      index = (index - 1) / 2
-      print(#function, "SWIM END", "IDX", index)
-    }
-  }
-}
+
+//extension PriorityQueue {
+//  private mutating func sink(_ index: Int) {
+//    var index = index
+//    while 2 * index + 1 < heap.count {
+//      var j = 2 * index + 1
+//      print(#function, "SINK START", "J", j, "IDX", index)
+//      
+//      // 배열의 끝에 접근하지 않도록 주의 + child 중에 누가 더 큰지(최대힙) 비교
+//      // 만약 오른쪽 녀석이 더 크다면 j 인덱스에 1을 더해준다(더 큰 쪽이 부모가 되어야 하기 때문)
+//      if j < (heap.count - 1), ordered(heap[j], heap[j + 1]) { j += 1 }
+//      // 만약 현재 노드가 자식보다 크다면(최대힙) 멈춘다.
+//      if !ordered(heap[index], heap[j]) { break }
+//      print(#function, "SINK END", "J", j, "IDX", index)
+//      heap.swapAt(index, j)
+//      index = j
+//    }
+//  }
+//  
+//  
+//  private mutating func swim(_ index: Int) {
+//    var index = index
+//    
+//    while index > 0, ordered(heap[(index - 1) / 2], heap[index]) {
+//      print(#function, "SWIM START", "IDX", index)
+//      heap.swapAt((index - 1) / 2, index)
+//      index = (index - 1) / 2
+//      print(#function, "SWIM END", "IDX", index)
+//    }
+//  }
+//}

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -7,12 +7,7 @@
 
 import Foundation
 
-public struct PriorityQueue<T: Comparable> {
-//  public static func hi() {
-//    let arr = [1,2,5,4,3]
-//    print(PriorityQueue<Int>(order: <, startingValues: arr))
-//  }
-  
+struct PriorityQueue<T: Comparable> {
   fileprivate(set) var heap = [T]()
   private let ordered: (T, T) -> Bool
   
@@ -38,7 +33,7 @@ public struct PriorityQueue<T: Comparable> {
   ///   - startingValues: An array of elements to initialize the PriorityQueue with.
   init(
     order: @escaping (T, T) -> Bool,
-    startingValues: [T] = []
+    _ startingValues: [T] = []
   ) {
     self.ordered = order
     self.heap = startingValues
@@ -50,7 +45,9 @@ public struct PriorityQueue<T: Comparable> {
       parentIndex -= 1
     }
   }
-  
+}
+
+extension PriorityQueue {
   // MARK: - Helpers
   /// Add a new element onto the Priority Queue. O(log n)
   ///
@@ -93,11 +90,10 @@ public struct PriorityQueue<T: Comparable> {
   /// Remove and return the element with the **highest priority** or **lowest** if ascending. O(log n)
   ///
   /// - Returns: The element with the highest priority in the Priority Queue, or nil if the Priority Queue is empty.
-  public mutating func pop() -> T? {
+  mutating func pop() -> T? {
     if heap.isEmpty { return nil }
     let count = heap.count
     if count == 1 { return heap.removeFirst() }
-    fastPop(newCount: count - 1)
     
     return heap.removeLast()
   }
@@ -142,33 +138,11 @@ public struct PriorityQueue<T: Comparable> {
     }
   }
   
-  /// Helper function for pop.
-  ///
-  /// Swaps the first and last elements, then sinks the first element.
-  ///
-  /// After executing this function, calling `heap.removeLast()` returns the popped element.
-  /// - Parameter newCount: The number of elements in heap after the `pop()` operation is complete.
-  private mutating func fastPop(newCount: Int) {
-    var index = 0
-    var heap = heap
-    heap.withUnsafeMutableBufferPointer { bufferPointer in
-      let _heap = bufferPointer.baseAddress! // guaranteed non-nil because count > 0
-      swap(&_heap[0], &_heap[newCount])
-      while 2 * index + 1 < newCount {
-        var j = 2 * index + 1
-        if j < (newCount - 1) && ordered(_heap[j], _heap[j+1]) { j += 1 }
-        if !ordered(_heap[index], _heap[j]) { return }
-        swap(&_heap[index], &_heap[j])
-        index = j
-      }
-    }
-  }
-  
-  mutating func removeMax() -> T? {
+  mutating func removeFirst() -> T? {
     let max = heap[0]
     heap.swapAt(0, heap.count - 1)
     sink(0)
-    return max
+    return heap.removeFirst()
   }
 }
 
@@ -195,8 +169,9 @@ extension PriorityQueue {
     let currentNode = heap[index]
     
     while index > 0, ordered(parent, currentNode) {
-      heap.swapAt((index - 1) / 2, index)
-      index = (index - 1) / 2
+      var parentIndex = (index - 1) / 2
+      heap.swapAt(parentIndex, index)
+      index = parentIndex
     }
   }
 }

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -1,0 +1,196 @@
+//
+//  PriorityQueue.swift
+//
+//
+//  Created by Celan on 3/19/24.
+//
+
+import Foundation
+
+public struct PriorityQueue<T: Comparable> {
+//  public static func hi() {
+//    let arr = [1,2,5,4,3]
+//    print(PriorityQueue<Int>(order: <, startingValues: arr))
+//  }
+  
+  fileprivate(set) var heap = [T]()
+  private let ordered: (T, T) -> Bool
+  
+  /// Numbers of elements in Priority Queue. O(1)
+  var count: Int { return heap.count }
+  
+  /// if the Priority Queue is empty, returns true. O(1)
+  var isEmpty: Bool { return heap.isEmpty }
+  
+  /// Get a look at the current highest priority item, without removing it. O(1)
+  ///
+  /// - Returns: The element with the highest priority in the Priority Queue, or nil if the Priority Queue is empty.
+  func peek() -> T? { return heap.first }
+  
+  /// Eliminate all of the elements from the Priority Queue, optionally replacing the order.
+  mutating func clear() { heap.removeAll() }
+  
+  // MARK: - Lifecycle
+  /// Creates a new PriorityQueue with the given custom ordering function.
+  ///
+  /// - Parameters:
+  ///   - order: A function that specifies whether its first argument should come after the second argument in the Priority Queue. Giving `<` means Max Heap, otherwise Min Heap.
+  ///   - startingValues: An array of elements to initialize the PriorityQueue with.
+  init(
+    order: @escaping (T, T) -> Bool,
+    startingValues: [T] = []
+  ) {
+    self.ordered = order
+    self.heap = startingValues
+    
+    var midIndex = heap.count / 2 - 1
+    
+    while midIndex >= 0 {
+      sink(midIndex)
+      midIndex -= 1
+    }
+  }
+  
+  // MARK: - Helpers
+  /// Add a new element onto the Priority Queue. O(log n)
+  ///
+  /// - Parameter element: The element to be inserted into the Priority Queue.
+  /// - Note: This function will **append** a element into heap Array.
+  mutating func push(_ element: T) {
+    heap.append(element)
+    swim(heap.count - 1)
+  }
+  
+  /// Add a new element onto a Priority Queue, limiting the size of the queue. O(n^2)
+  /// If the size limit has been reached, the lowest priority element will be removed and returned.
+  /// It acts like a buffer.
+  ///
+  /// - Parameters:
+  ///   - element: The element to be inserted into the Priority Queue.
+  ///   - maxCount: The Priority Queue will not grow further if its count >= maxCount.
+  /// - Returns: the discarded lowest priority element, or `nil` if count < maxCount
+  /// - Note: Since this is a binary heap, there is no easy way to find the lowest priority item, so this method **can be inefficient**.
+  /// - Note: Also note, that only one item will be removed, even if count > maxCount by more than one.
+  mutating func push(_ element: T, maxCount: Int) -> T? {
+    precondition(maxCount > 0)
+    
+    if count < maxCount {
+      push(element)
+    } else if heap.count >= maxCount {
+      // find the min priority element (ironically using max here)
+      if let discard = heap.max(by: ordered) {
+        if ordered(discard, element) { return element }
+        // if
+        push(element)
+        remove(discard)
+        return discard
+      }
+    }
+    
+    return nil
+  }
+  
+  /// Remove and return the element with the **highest priority** or **lowest** if ascending. O(log n)
+  ///
+  /// - Returns: The element with the highest priority in the Priority Queue, or nil if the Priority Queue is empty.
+  public mutating func pop() -> T? {
+    if heap.isEmpty { return nil }
+    let count = heap.count
+    if count == 1 { return heap.removeFirst() }
+    fastPop(newCount: count - 1)
+    
+    return heap.removeLast()
+  }
+  
+  /// Removes the first occurence of a particular item. Finds it by value comparison using `==` O(n)
+  /// Silently exits if no occurrence found.
+  ///
+  /// - Parameter item: The item to remove the first occurrence of.
+  ///
+  /// ## Example
+  ///
+  /// ```plain
+  /// given: heap = [1,2,3,4,5] | remove 3 | index == 2
+  /// heap[idx] goes to last position (swapAt)
+  /// and pops (removeLast) then rearrange the Pritority Queue.
+  /// If you removed the last item, swim doesn't get called.
+  /// ```
+  mutating func remove(_ item: T) {
+    if let index = heap.firstIndex(of: item) {
+      
+      heap.swapAt(index, heap.count - 1)
+      heap.removeLast()
+      
+      if index < heap.count {
+        swim(index)
+        sink(index)
+      }
+    }
+  }
+  
+  /// Removes **all occurences** of a particular item.
+  /// Finds it by value comparison using ==. O(n^2)
+  /// Silently exits if no occurrence found.
+  ///
+  /// - Parameter item: The item to remove.
+  mutating func removeAll(_ item: T) {
+    var lastCount = heap.count
+    remove(item)
+    
+    while heap.count < lastCount {
+      lastCount = heap.count
+      remove(item)
+    }
+  }
+  
+  /// Helper function for pop.
+  ///
+  /// Swaps the first and last elements, then sinks the first element.
+  ///
+  /// After executing this function, calling `heap.removeLast()` returns the popped element.
+  /// - Parameter newCount: The number of elements in heap after the `pop()` operation is complete.
+  private mutating func fastPop(newCount: Int) {
+    var index = 0
+    var heap = heap
+    heap.withUnsafeMutableBufferPointer { bufferPointer in
+      let _heap = bufferPointer.baseAddress! // guaranteed non-nil because count > 0
+      swap(&_heap[0], &_heap[newCount])
+      while 2 * index + 1 < newCount {
+        var j = 2 * index + 1
+        if j < (newCount - 1) && ordered(_heap[j], _heap[j+1]) { j += 1 }
+        if !ordered(_heap[index], _heap[j]) { return }
+        swap(&_heap[index], &_heap[j])
+        index = j
+      }
+    }
+  }
+}
+
+// MARK: - swim and sink
+extension PriorityQueue {
+  private mutating func sink(_ index: Int) {
+    var index = index
+    while 2 * index + 1 < heap.count {
+      var j = 2 * index + 1
+      print(#function, "SINK START", "J", j, "IDX", index)
+      
+      if j < (heap.count - 1) && ordered(heap[j], heap[j + 1]) { j += 1 }
+      if !ordered(heap[index], heap[j]) { break }
+      print(#function, "SINK END", "J", j, "IDX", index)
+      heap.swapAt(index, j)
+      index = j
+    }
+  }
+  
+  
+  private mutating func swim(_ index: Int) {
+    var index = index
+    
+    while index > 0 && ordered(heap[(index - 1) / 2], heap[index]) {
+      print(#function, "SWIM START", "IDX", index)
+      heap.swapAt((index - 1) / 2, index)
+      index = (index - 1) / 2
+      print(#function, "SWIM END", "IDX", index)
+    }
+  }
+}

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -173,34 +173,30 @@ public struct PriorityQueue<T: Comparable> {
 }
 
 // MARK: - swim and sink
-
-//extension PriorityQueue {
-//  private mutating func sink(_ index: Int) {
-//    var index = index
-//    while 2 * index + 1 < heap.count {
-//      var j = 2 * index + 1
-//      print(#function, "SINK START", "J", j, "IDX", index)
-//      
-//      // 배열의 끝에 접근하지 않도록 주의 + child 중에 누가 더 큰지(최대힙) 비교
-//      // 만약 오른쪽 녀석이 더 크다면 j 인덱스에 1을 더해준다(더 큰 쪽이 부모가 되어야 하기 때문)
-//      if j < (heap.count - 1), ordered(heap[j], heap[j + 1]) { j += 1 }
-//      // 만약 현재 노드가 자식보다 크다면(최대힙) 멈춘다.
-//      if !ordered(heap[index], heap[j]) { break }
-//      print(#function, "SINK END", "J", j, "IDX", index)
-//      heap.swapAt(index, j)
-//      index = j
-//    }
-//  }
-//  
-//  
-//  private mutating func swim(_ index: Int) {
-//    var index = index
-//    
-//    while index > 0, ordered(heap[(index - 1) / 2], heap[index]) {
-//      print(#function, "SWIM START", "IDX", index)
-//      heap.swapAt((index - 1) / 2, index)
-//      index = (index - 1) / 2
-//      print(#function, "SWIM END", "IDX", index)
-//    }
-//  }
-//}
+extension PriorityQueue {
+  mutating func sink(_ index: Int) {
+    var index = index
+    
+    while index * 2 + 1 < heap.count {
+      var childIndex = index * 2 + 1
+      if
+        childIndex < (heap.count - 1),
+        ordered(heap[childIndex], heap[childIndex + 1]) { childIndex += 1 }
+      
+      if !ordered(heap[index], heap[childIndex]) { break }
+      heap.swapAt(index, childIndex)
+      index = childIndex
+    }
+  }
+  
+  mutating func swim(_ index: Int) {
+    var index = index
+    let parent = heap[(index - 1) / 2]
+    let currentNode = heap[index]
+    
+    while index > 0, ordered(parent, currentNode) {
+      heap.swapAt((index - 1) / 2, index)
+      index = (index - 1) / 2
+    }
+  }
+}

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -77,7 +77,6 @@ extension PriorityQueue {
       // find the min priority element (ironically using max here)
       if let discard = heap.max(by: ordered) {
         if ordered(discard, element) { return element }
-        // if
         push(element)
         remove(discard)
         return discard
@@ -94,8 +93,10 @@ extension PriorityQueue {
     if heap.isEmpty { return nil }
     let count = heap.count
     if count == 1 { return heap.removeFirst() }
-    
-    return heap.removeLast()
+    heap.swapAt(0, heap.count - 1)
+    let removeTarget = heap.removeLast()
+    sink(0)
+    return removeTarget
   }
   
   /// Removes the first occurence of a particular item. Finds it by value comparison using `==` O(n)
@@ -136,13 +137,6 @@ extension PriorityQueue {
       lastCount = heap.count
       remove(item)
     }
-  }
-  
-  mutating func removeFirst() -> T? {
-    let max = heap[0]
-    heap.swapAt(0, heap.count - 1)
-    sink(0)
-    return heap.removeFirst()
   }
 }
 

--- a/Sources/CLToaster/Common/PriorityQueue.swift
+++ b/Sources/CLToaster/Common/PriorityQueue.swift
@@ -149,9 +149,11 @@ extension PriorityQueue {
       var childIndex = index * 2 + 1
       if
         childIndex < (heap.count - 1),
-        ordered(heap[childIndex], heap[childIndex + 1]) { childIndex += 1 }
+        ordered(heap[childIndex], heap[childIndex + 1]) {
+        childIndex += 1
+      }
       
-      if !ordered(heap[index], heap[childIndex]) { break }
+      if ordered(heap[childIndex], heap[index]) { break }
       heap.swapAt(index, childIndex)
       index = childIndex
     }
@@ -159,10 +161,8 @@ extension PriorityQueue {
   
   mutating func swim(_ index: Int) {
     var index = index
-    let parent = heap[(index - 1) / 2]
-    let currentNode = heap[index]
     
-    while index > 0, ordered(parent, currentNode) {
+    while index > 0, !ordered(heap[index], heap[(index - 1) / 2]) {
       var parentIndex = (index - 1) / 2
       heap.swapAt(parentIndex, index)
       index = parentIndex

--- a/Sources/CLToaster/UIKitToaster/Data/CLToastUIKitData.swift
+++ b/Sources/CLToaster/UIKitToaster/Data/CLToastUIKitData.swift
@@ -15,11 +15,21 @@ struct CLToastUIKitData {
     style: CLToastStyle,
     animation: any CLToastUIKitAnimation = CLToastUIKitAnimationClient(toastAnimations: CLToastAnimations()),
     display: CLToastDisplaySection,
-    completion: ( () -> Void)? = nil
+    completion: (() -> Void)? = nil
   ) {
     self.style = style
     self.animation = animation
     self.display = display
     self.completion = completion
+  }
+}
+
+extension CLToastUIKitData: Comparable {
+  static func < (lhs: CLToastUIKitData, rhs: CLToastUIKitData) -> Bool {
+    lhs.style.presentPriority.rawValue < rhs.style.presentPriority.rawValue
+  }
+  
+  static func == (lhs: CLToastUIKitData, rhs: CLToastUIKitData) -> Bool {
+    lhs.style.presentPriority.rawValue == rhs.style.presentPriority.rawValue
   }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈

| ⚒️ Title | `우선순위 큐 구현` | 
| :--- | :--- |
| 📜 **Description** | 우선순위 큐를 구현합니다! |
| 📌 **Issue Number** | #46 |

---

## 작업 사항

1. 우선순위 큐를 구현합니다.
2. 클래식한 우선순위 큐의 요구사항에 맞게 peek, pop, push, clear를 갖습니다.
3. 재정렬을 위한 sink-swim을 도입합니다(Sadgewick)

### `Logics`
```swift
extension PriorityQueue {
  mutating func sink(_ index: Int) {
    var index = index
    
    // 자식 노드가 있다면, 부모를 자식과 비교하고 우선순위에 맞게 재정렬
    while index * 2 + 1 < heap.count {
      var childIndex = index * 2 + 1
      if
        childIndex < (heap.count - 1),
        // 더 우선순위가 큰 자식을 기준으로 재정렬을 하도록 인덱스 조정
        ordered(heap[childIndex], heap[childIndex + 1]) { childIndex += 1 }
     
      if !ordered(heap[index], heap[childIndex]) { break }
      heap.swapAt(index, childIndex)
      index = childIndex
    }
  }
  
  mutating func swim(_ index: Int) {
    var index = index
    let parent = heap[(index - 1) / 2]
    let currentNode = heap[index]
    
    while index > 0, ordered(parent, currentNode) {
      var parentIndex = (index - 1) / 2
      heap.swapAt(parentIndex, index)
      index = parentIndex
    }
  }
}
```
---
